### PR TITLE
ls -> dir in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use the application, type in the following commands in GNU/Linux terminal.
 `git clone https://github.com/palahsu/DDoS-Ripper`
 
 `cd DDoS-Ripper`
-` ls`
+` dir`
 
 `python3 DRipper.py` OR `python DRipper.py`
 


### PR DESCRIPTION
On windows, the command `ls` is not valid. 
Use `dir` instead.